### PR TITLE
Add index to DupMetrics

### DIFF
--- a/WholeGenomeSingleSampleQc.wdl
+++ b/WholeGenomeSingleSampleQc.wdl
@@ -132,6 +132,7 @@ workflow WholeGenomeSingleSampleQc {
   call QC.CollectDuplicateMetrics as CollectDuplicateMetrics {
     input:
       input_bam = input_bam,
+      input_bam_index = BuildBamIndex.bam_index,
       output_bam_prefix = base_name,
       ref_dict = ref_dict,
       ref_fasta = ref_fasta,

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -249,6 +249,7 @@ task CollectHsMetrics {
 task CollectDuplicateMetrics {
   input {
     File input_bam
+    File input_bam_index
     String output_bam_prefix
     File ref_dict
     File ref_fasta


### PR DESCRIPTION
Add BAM/CRAM index to DuplicateMetrics step to avoid regenerating an index. Closes #33