### PR TITLE
Normalize BAM/CRAM path during Index

### DIFF
--- a/WholeGenomeSingleSampleQc.wdl
+++ b/WholeGenomeSingleSampleQc.wdl
@@ -31,7 +31,6 @@ import "https://raw.githubusercontent.com/jasonwalker80/qc-analysis-pipeline/lin
 workflow WholeGenomeSingleSampleQc {
   input {
     File input_bam
-    Boolean is_bam
     File ref_cache
     File ref_dict
     File ref_fasta
@@ -53,7 +52,6 @@ workflow WholeGenomeSingleSampleQc {
     input:
       input_bam = input_bam,
       base_name = base_name,
-      is_bam = is_bam,
       ref_cache = ref_cache,
       preemptible_tries = preemptible_tries
   }
@@ -144,9 +142,6 @@ workflow WholeGenomeSingleSampleQc {
 
   # Outputs that will be retained when execution is complete
   output {
-
-    File bam = BuildBamIndex.bam
-    File bam_index = BuildBamIndex.bam_index
 
     File validation_report = ValidateSamFile.report
 

--- a/WholeGenomeSingleSampleQc.wdl
+++ b/WholeGenomeSingleSampleQc.wdl
@@ -24,7 +24,7 @@ version 1.0
 ## - [VerifyBamID2](https://github.com/Griffan/VerifyBamID)
 
 # Git URL import
-import "https://raw.githubusercontent.com/jasonwalker80/qc-analysis-pipeline/link_and_index/tasks/Qc.wdl" as QC
+import "https://raw.githubusercontent.com/genome/qc-analysis-pipeline/master/tasks/Qc.wdl" as QC
 #import "./tasks/Qc.wdl" as QC
 
 # WORKFLOW DEFINITION

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -311,8 +311,8 @@ task BuildBamIndex {
     preemptible: preemptible_tries
   }
   output {
-    File bam = "~{bam_link}"
-    File bam_index = sub(sub(input_bam, "bam$", "bam.bai"), "cram$", "cram.crai")
+    File bam = bam_link
+    File bam_index = sub(sub(bam_link, "bam$", "bam.bai"), "cram$", "cram.crai")
   }
 }
 

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -293,8 +293,8 @@ task BuildBamIndex {
   String bam_link = base_name + "." + if is_bam then "bam" else "cram"
 
   command {
-    # Move the BAM/CRAM to a harmonized name and path
-    mv ~{input_bam} ~{bam_link}
+    # Link the BAM/CRAM to a harmonized name and path
+    ln -s ~{input_bam} ~{bam_link}
 
     # build the reference sequence cache
     tar -zxf ~{ref_cache}

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -283,7 +283,6 @@ task BuildBamIndex {
   input {
     File input_bam
     String base_name
-    Boolean is_bam
     File ref_cache
     Int preemptible_tries
   }

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -290,8 +290,8 @@ task BuildBamIndex {
 
   Float ref_size = size(ref_cache, "GiB") * 5 + 1.0
   Int disk_size = ceil(size(input_bam, "GiB") + ref_size) + 20
-  String bam_link = base_name + "." + if is_bam then "bam" else "cram"
-
+  String bam_link = sub(basename(input_bam), basename(basename(input_bam, ".bam"), ".cram"), base_name )
+  
   command {
     # Link the BAM/CRAM to a harmonized name and path
     ln -s ~{input_bam} ~{bam_link}

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -293,8 +293,8 @@ task BuildBamIndex {
   String bam_link = base_name + "." + if is_bam then "bam" else "cram"
 
   command {
-    # Link the BAM/CRAM to a harmonized name and path
-    ln -s ~{input_bam} ~{bam_link}
+    # Move the BAM/CRAM to a harmonized name and path
+    mv ~{input_bam} ~{bam_link}
 
     # build the reference sequence cache
     tar -zxf ~{ref_cache}


### PR DESCRIPTION
Link during the index step and use normalized BAM/CRAM path for downstream steps. This replaces PR #45 