### PR TITLE
Save the BAM/CRAM index.

### DIFF
--- a/WholeGenomeSingleSampleQc.wdl
+++ b/WholeGenomeSingleSampleQc.wdl
@@ -171,5 +171,6 @@ workflow SingleSampleQc {
     File? hs_metrics = CollectHsMetrics.metrics
 
     File input_bam_md5 = CalculateChecksum.md5
+    File input_bam_index = BuildBamIndex.bam_index
   }
 }


### PR DESCRIPTION
This is like #57 but for the `no_validatesamfile` alternate version of the workflow.