### PR TITLE
Fixup checksum generation.

### DIFF
--- a/SingleSampleQc.wdl
+++ b/SingleSampleQc.wdl
@@ -171,6 +171,7 @@ workflow SingleSampleQc {
     File? hs_metrics = CollectHsMetrics.metrics
 
     File input_bam_md5 = CalculateChecksum.md5
+    String input_bam_md5_hash = CalculateChecksum.md5_hash
     File input_bam_index = BuildBamIndex.bam_index
   }
 }

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -367,8 +367,10 @@ task CalculateChecksum {
 
   Int disk_size = ceil(size(input_bam, "GiB")) + 20
 
+  String output_name = basename(input_bam)
+
   command {
-    md5sum ~{input_bam} > ~{input_bam}.md5
+    md5sum ~{input_bam} > ~{output_name}.md5
   }
   runtime {
     preemptible: preemptible_tries
@@ -377,6 +379,7 @@ task CalculateChecksum {
     docker: "us.gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
   }
   output {
-    File md5 = "~{input_bam}.md5"
+    File md5 = "~{output_name}.md5"
+    String md5_hash = sub(read_string(md5), " .+$", "")
   }
 }


### PR DESCRIPTION
* Don't use the full input path as the output location.
* Extract the MD5 value as a String output.