### PR TITLE
Add a version of the RxIdentifier workflow that takes index as an input

### DIFF
--- a/PreindexedRxIdentifier.wdl
+++ b/PreindexedRxIdentifier.wdl
@@ -1,0 +1,59 @@
+
+version 1.0
+
+## Portions Copyright Broad Institute, 2018
+##
+## This WDL pipeline implements QC in human whole-genome or exome/targeted sequencing data.
+##
+## Requirements/expectations
+## - Human paired-end sequencing data in aligned BAM or CRAM format
+## - Input BAM/CRAM files must additionally comply with the following requirements:
+## - - files must pass validation by ValidateSamFile
+## - - reads are provided in query-sorted order
+## - - all reads must have an RG tag
+## - Reference genome must be Hg38 with ALT contigs
+##
+## Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
+## For program versions, see docker containers.
+##
+## LICENSING :
+## This script is released under the WDL open source code license (BSD-3).
+## Full license text at https://github.com/openwdl/wdl/blob/master/LICENSE
+## Note however that the programs it calls may be subject to different licenses. 
+## Users are responsible for checking that they are authorized to run all programs before running this script.
+## - [Picard](https://broadinstitute.github.io/picard/)
+## - [VerifyBamID2](https://github.com/Griffan/VerifyBamID)
+
+# Git URL import
+import "tasks/Qc.wdl" as QC
+
+# WORKFLOW DEFINITION
+workflow RxIdentifier {
+  input {
+    File input_bam
+    File input_bam_index
+    String base_name
+    Int preemptible_tries
+  }
+
+  # Collect BAM/CRAM index stats
+  call QC.BamIndexStats as BamIndexStats {
+    input:
+      input_bam = input_bam,
+      input_bam_index = input_bam_index,
+      preemptible_tries = preemptible_tries
+  }
+
+  call QC.RxIdentifier as RxIdentifier {
+    input:
+      idxstats = BamIndexStats.idxstats,
+      sample_id = base_name,
+      preemptible_tries = preemptible_tries
+  }
+
+  output {
+    File bam_idxstats = BamIndexStats.idxstats 
+    File bam_rx_result = RxIdentifier.rx_result
+    String rx_value = RxIdentifier.rx_value
+  }
+}

--- a/RxIdentifier.wdl
+++ b/RxIdentifier.wdl
@@ -27,7 +27,7 @@ version 1.0
 import "tasks/Qc.wdl" as QC
 
 # WORKFLOW DEFINITION
-workflow Idxstats {
+workflow RxIdentification {
   input {
     File input_bam
     String base_name
@@ -63,5 +63,6 @@ workflow Idxstats {
     File bam_index = BuildBamIndex.bam_index
     File bam_idxstats = BamIndexStats.idxstats 
     File bam_rx_result = RxIdentifier.rx_result
+    String bam_rx_value = RxIdentifier.rx_value
   }
 }

--- a/SingleSampleQc.wdl
+++ b/SingleSampleQc.wdl
@@ -206,5 +206,6 @@ workflow SingleSampleQc {
     File input_bam_index = BuildBamIndex.bam_index
     File input_bam_idxstats = BamIndexStats.idxstats
     File input_bam_rx_result = RxIdentifier.rx_result
+    String input_bam_rx_value = RxIdentifier.rx_value
   }
 }

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -429,6 +429,7 @@ task RxIdentifier {
   }
   output {
     File rx_result = "~{output_name}"
+    String rx_value = read_tsv(output_name)[0][5]
   }
 }
 


### PR DESCRIPTION
The bam index step is the dominant cost of the workflow, so better to skip it when we can!

(This PR is based off of #67.)