### PR TITLE
Metric Extraction and Evaluation

### DIFF
--- a/SingleSampleQc.wdl
+++ b/SingleSampleQc.wdl
@@ -42,6 +42,8 @@ workflow SingleSampleQc {
     File contamination_sites_mu
     Boolean is_wgs
     Boolean? is_outlier_data
+
+    File evaluation_thresholds
   }
 
   # Not overridable:
@@ -172,6 +174,19 @@ workflow SingleSampleQc {
       preemptible_tries = preemptible_tries
   }
 
+  call QC.EvaluateMetrics as EvaluateMetrics {
+    input:
+      thresholds = evaluation_thresholds,
+      alignment_summary_metrics = CollectAggregationMetrics.alignment_summary_metrics,
+      duplication_metrics = CollectDuplicateMetrics.duplication_metrics,
+      insert_size_metrics = CollectAggregationMetrics.insert_size_metrics,
+      quality_yield_metrics = CollectQualityYieldMetrics.metrics,
+      contamination_metrics = CheckContamination.metrics,
+      hs_metrics = CollectHsMetrics.hs_metrics,
+      wgs_metrics = CollectRawWgsMetrics.metrics,
+      preemptible_tries = preemptible_tries
+  }
+
   # Outputs that will be retained when execution is complete
   output {
 
@@ -229,5 +244,9 @@ workflow SingleSampleQc {
     File input_bam_idxstats = BamIndexStats.idxstats
     File input_bam_rx_result = RxIdentifier.rx_result
     String input_bam_rx_value = RxIdentifier.rx_value
+
+    File evaluated_metrics_file = EvaluateMetrics.evaluated_metrics_file
+    Map[String, String] evaluated_metrics = EvaluateMetrics.evaluated_metrics
+    String overall_evaluation = EvaluateMetrics.overall_evaluation
   }
 }

--- a/SingleSampleQc.wdl
+++ b/SingleSampleQc.wdl
@@ -177,14 +177,22 @@ workflow SingleSampleQc {
 
     File validation_report = ValidateSamFile.report
 
-    File alignment_summary_metrics = CollectAggregationMetrics.alignment_summary_metrics
+    File alignment_summary_metrics_file = CollectAggregationMetrics.alignment_summary_metrics_file
+    String pct_chimeras = CollectAggregationMetrics.pct_chimeras
+    String read1_pf_mismatch_rate = CollectAggregationMetrics.read1_pf_mismatch_rate
+    String read2_pf_mismatch_rate = CollectAggregationMetrics.read2_pf_mismatch_rate
+
     File bait_bias_detail_metrics = CollectAggregationMetrics.bait_bias_detail_metrics
     File bait_bias_summary_metrics = CollectAggregationMetrics.bait_bias_summary_metrics
     File gc_bias_detail_metrics = CollectAggregationMetrics.gc_bias_detail_metrics
     File gc_bias_pdf = CollectAggregationMetrics.gc_bias_pdf
     File gc_bias_summary_metrics = CollectAggregationMetrics.gc_bias_summary_metrics
+
     File insert_size_histogram_pdf = CollectAggregationMetrics.insert_size_histogram_pdf
-    File insert_size_metrics = CollectAggregationMetrics.insert_size_metrics
+    File insert_size_metrics_file = CollectAggregationMetrics.insert_size_metrics_file
+    String median_insert_size = CollectAggregationMetrics.median_insert_size
+    String median_absolute_deviation = CollectAggregationMetrics.median_absolute_deviation
+
     File pre_adapter_detail_metrics = CollectAggregationMetrics.pre_adapter_detail_metrics
     File pre_adapter_summary_metrics = CollectAggregationMetrics.pre_adapter_summary_metrics
     File quality_distribution_pdf = CollectAggregationMetrics.quality_distribution_pdf
@@ -192,14 +200,28 @@ workflow SingleSampleQc {
     File error_summary_metrics = CollectAggregationMetrics.error_summary_metrics
 
     File selfSM = CheckContamination.selfSM
-    Float contamination = CheckContamination.contamination    
+    Float contamination = CheckContamination.contamination
 
-    File duplication_metrics = CollectDuplicateMetrics.duplication_metrics
+    File duplication_metrics_file = CollectDuplicateMetrics.duplication_metrics_file
+    String percent_duplication = CollectDuplicateMetrics.percent_duplication
 
-    File quality_yield_metrics = CollectQualityYieldMetrics.quality_yield_metrics
+    File quality_yield_metrics = CollectQualityYieldMetrics.metrics_file
+    String q20_bases = CollectQualityYieldMetrics.q20_bases
+    String pf_q20_bases = CollectQualityYieldMetrics.pf_q20_bases
+    String q30_bases = CollectQualityYieldMetrics.q30_bases
+    String pf_q30_bases = CollectQualityYieldMetrics.pf_q30_bases
 
-    File? raw_wgs_metrics = CollectRawWgsMetrics.metrics
-    File? hs_metrics = CollectHsMetrics.metrics
+    File? raw_wgs_metrics = CollectRawWgsMetrics.metrics_file
+    String? mean_coverage = CollectRawWgsMetrics.mean_coverage
+    String? pct_10x = CollectRawWgsMetrics.pct_10x
+    String? pct_20x = CollectRawWgsMetrics.pct_20x
+    String? pct_30x = CollectRawWgsMetrics.pct_30x
+
+    File? hs_metrics = CollectHsMetrics.hs_metrics_file
+    String? mean_target_coverage = CollectHsMetrics.mean_target_coverage
+    String? pct_target_bases_10x = CollectHsMetrics.pct_target_bases_10x
+    String? pct_target_bases_20x = CollectHsMetrics.pct_target_bases_20x
+    String? pct_target_bases_30x = CollectHsMetrics.pct_target_bases_30x
 
     File input_bam_md5 = CalculateChecksum.md5
     String input_bam_md5_hash = CalculateChecksum.md5_hash

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -29,14 +29,18 @@ task CollectQualityYieldMetrics {
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
   Int disk_size = ceil(size(input_bam, "GiB") + ref_size) + 20
 
-  command {
+  String metric_object_file = "~{metrics_filename}.only_metrics"
+
+  command <<<
     java -Xms2000m -jar /usr/picard/picard.jar \
       CollectQualityYieldMetrics \
       INPUT=~{input_bam} \
       REFERENCE_SEQUENCE=~{ref_fasta} \
       OQ=true \
       OUTPUT=~{metrics_filename}
-  }
+
+    grep -v '#' ~{metrics_filename} | grep '.\+' | perl -E 'my ($keys, $values) = <>; chomp $keys; chomp $values; my @k = split("\t", $keys); my @v = split("\t", $values); for(0..$#k) { say join("\t", $k[$_], $v[$_]); }' > "~{metric_object_file}"
+  >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.21.7"
     disks: "local-disk " + disk_size + " HDD"
@@ -44,7 +48,12 @@ task CollectQualityYieldMetrics {
     preemptible: preemptible_tries
   }
   output {
-    File quality_yield_metrics = "~{metrics_filename}"
+    File metrics_file = "~{metrics_filename}"
+    Map[String, String] metrics = read_map(metric_object_file)
+    String q20_bases = metrics["Q20_BASES"]
+    String pf_q20_bases = metrics["PF_Q20_BASES"]
+    String q30_bases = metrics["Q30_BASES"]
+    String pf_q30_bases = metrics["PF_Q30_BASES"]
   }
 }
 
@@ -64,7 +73,10 @@ task CollectAggregationMetrics {
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
   Int disk_size = ceil(size(input_bam, "GiB") + ref_size) + 20
 
-  command {
+  String alignment_summary_metric_object_file = "~{base_name}.alignment_summary_metrics.only_metrics"
+  String insert_size_metric_object_file = "~{base_name}.insert_size_metrics.only_metrics"
+
+  command <<<
     # These are optionally generated, but need to exist for Cromwell's sake
     touch ~{base_name}.gc_bias.detail_metrics \
       ~{base_name}.gc_bias.pdf \
@@ -87,7 +99,13 @@ task CollectAggregationMetrics {
       METRIC_ACCUMULATION_LEVEL=null \
       METRIC_ACCUMULATION_LEVEL=SAMPLE \
       METRIC_ACCUMULATION_LEVEL=LIBRARY
-  }
+
+    grep -v '#' '~{base_name}.alignment_summary_metrics' | grep '.\+' | perl -E 'my ($keys, @values) = <>; chomp $keys; chomp for @values; my @k = split("\t", $keys); for my $values (@values[0..2]) { my @v = split("\t", $values); my $category = $v[0]; for(0..($#k-2)) { say join("\t", join("-",$k[$_], $category), $v[$_]); }; }' > ~{alignment_summary_metric_object_file}
+
+    grep -v '#' '~{base_name}.insert_size_metrics' | grep '.\+' | perl -E 'my ($keys, $values) = <>; chomp $keys; chomp $values; my @k = split("\t", $keys); my @v = split("\t", $values); for(0..($#k-2)) { say join("\t", $k[$_], $v[$_]); }' > ~{insert_size_metric_object_file}
+
+
+  >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.21.7"
     memory: "7 GiB"
@@ -95,14 +113,23 @@ task CollectAggregationMetrics {
     preemptible: preemptible_tries
   }
   output {
-    File alignment_summary_metrics = "~{base_name}.alignment_summary_metrics"
+    File alignment_summary_metrics_file = "~{base_name}.alignment_summary_metrics"
+    Map[String, String] alignment_summary_metrics = read_map(alignment_summary_metric_object_file)
+    String pct_chimeras = alignment_summary_metrics["PCT_CHIMERAS-PAIR"]
+    String read1_pf_mismatch_rate = alignment_summary_metrics["PF_MISMATCH_RATE-FIRST_OF_PAIR"]
+    String read2_pf_mismatch_rate = alignment_summary_metrics["PF_MISMATCH_RATE-SECOND_OF_PAIR"]
+
     File bait_bias_detail_metrics = "~{base_name}.bait_bias_detail_metrics"
     File bait_bias_summary_metrics = "~{base_name}.bait_bias_summary_metrics"
     File gc_bias_detail_metrics = "~{base_name}.gc_bias.detail_metrics"
     File gc_bias_pdf = "~{base_name}.gc_bias.pdf"
     File gc_bias_summary_metrics = "~{base_name}.gc_bias.summary_metrics"
     File insert_size_histogram_pdf = "~{base_name}.insert_size_histogram.pdf"
-    File insert_size_metrics = "~{base_name}.insert_size_metrics"
+    File insert_size_metrics_file = "~{base_name}.insert_size_metrics"
+    Map[String, String] insert_size_metrics = read_map(insert_size_metric_object_file)
+    String median_insert_size = insert_size_metrics["MEDIAN_INSERT_SIZE"]
+    String median_absolute_deviation = insert_size_metrics["MEDIAN_ABSOLUTE_DEVIATION"]
+
     File pre_adapter_detail_metrics = "~{base_name}.pre_adapter_detail_metrics"
     File pre_adapter_summary_metrics = "~{base_name}.pre_adapter_summary_metrics"
     File quality_distribution_pdf = "~{base_name}.quality_distribution.pdf"
@@ -172,7 +199,9 @@ task CollectRawWgsMetrics {
   Int memory_size = ceil((if (disk_size < 110) then 5 else 7) * memory_multiplier)
   String java_memory_size = (memory_size - 1) * 1000
 
-  command {
+  String wgs_metric_object_file = '~{metrics_filename}.only_metrics'
+
+  command <<<
     java -Xms~{java_memory_size}m -jar /usr/picard/picard.jar \
       CollectWgsMetrics \
       INPUT=~{input_bam} \
@@ -187,7 +216,10 @@ task CollectRawWgsMetrics {
       READ_LENGTH=~{read_length}
 
     sed -i.original 's/picard.analysis.WgsMetrics/picard.analysis.CollectWgsMetrics\$WgsMetrics/' ~{metrics_filename}
-  }
+
+    grep -v '#' '~{metrics_filename}' | grep '.\+' | perl -E 'my ($keys, $values) = <>; chomp $keys; chomp $values; my @k = split("\t", $keys); my @v = split("\t", $values); for(0..$#k) { say join("\t", $k[$_], $v[$_]); }' > ~{wgs_metric_object_file}
+
+  >>>
   runtime {
     # Using older image due to: https://github.com/broadinstitute/picard/issues/1402
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.20.4"
@@ -196,7 +228,12 @@ task CollectRawWgsMetrics {
     disks: "local-disk " + disk_size + " HDD"
   }
   output {
-    File metrics = "~{metrics_filename}"
+    File metrics_file = "~{metrics_filename}"
+    Map[String, String] metrics = read_map(wgs_metric_object_file)
+    String mean_coverage = metrics["MEAN_COVERAGE"]
+    String pct_10x = metrics["PCT_10X"]
+    String pct_20x = metrics["PCT_20X"]
+    String pct_30x = metrics["PCT_30X"]
   }
 }
 
@@ -221,8 +258,10 @@ task CollectHsMetrics {
   Int memory_size = if rounded_memory_size < 7 then 7 else rounded_memory_size
   Int java_memory_size = (memory_size - 1) * 1000
 
+  String hs_metric_object_file = "~{metrics_filename}.only_metrics"
+
   # There are probably more metrics we want to generate with this tool
-  command {
+  command <<<
     java -Xms~{java_memory_size}m -jar /usr/picard/picard.jar \
       CollectHsMetrics \
       INPUT=~{input_bam} \
@@ -233,7 +272,10 @@ task CollectHsMetrics {
       METRIC_ACCUMULATION_LEVEL=null \
       METRIC_ACCUMULATION_LEVEL=SAMPLE \
       OUTPUT=~{metrics_filename}
-  }
+
+grep -v '#' '~{metrics_filename}' | grep '.\+' | perl -E 'my ($keys, $values) = <>; chomp $keys; chomp $values; my @k = split("\t", $keys); my @v = split("\t", $values); for(0..$#k) { say join("\t", $k[$_], $v[$_]); }' > ~{hs_metric_object_file}
+
+  >>>
 
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.21.7"
@@ -243,7 +285,12 @@ task CollectHsMetrics {
   }
 
   output {
-    File metrics = metrics_filename
+    File hs_metrics_file = metrics_filename
+    Map[String, String] hs_metrics = read_map(hs_metric_object_file)
+    String mean_target_coverage = hs_metrics["MEAN_TARGET_COVERAGE"]
+    String pct_target_bases_10x = hs_metrics["PCT_TARGET_BASES_10X"]
+    String pct_target_bases_20x = hs_metrics["PCT_TARGET_BASES_20X"]
+    String pct_target_bases_30x = hs_metrics["PCT_TARGET_BASES_30X"]
   }
 }
 
@@ -262,14 +309,19 @@ task CollectDuplicateMetrics {
   Float ref_size = size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB") + size(ref_dict, "GiB")
   Int disk_size = ceil(size(input_bam, "GiB") + ref_size) + 20
 
-  command {
+  String duplication_metric_object_file = '~{output_bam_prefix}.duplication_metrics.metrics_only'
+
+  command <<<
     java -Xms5000m -jar /usr/picard/picard.jar \
       CollectDuplicateMetrics \
       METRICS_FILE=~{output_bam_prefix}.duplication_metrics \
       INPUT=~{input_bam} \
       ASSUME_SORTED=true \
       REFERENCE_SEQUENCE=~{ref_fasta}
-  }
+
+    grep -v '#' '~{output_bam_prefix}.duplication_metrics' | grep '.\+' | perl -E 'my ($keys, $values) = <>; chomp $keys; chomp $values; my @k = split("\t", $keys); my @v = split("\t", $values); for(0..$#k) { say join("\t", $k[$_], $v[$_]); }'      > ~{duplication_metric_object_file}
+
+  >>>
   runtime {
     docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.21.7"
     memory: "7 GiB"
@@ -277,7 +329,9 @@ task CollectDuplicateMetrics {
     preemptible: preemptible_tries
   }
   output {
-    File duplication_metrics = "~{output_bam_prefix}.duplication_metrics"
+    File duplication_metrics_file = "~{output_bam_prefix}.duplication_metrics"
+    Map[String, String] duplication_metrics = read_map(duplication_metric_object_file)
+    String percent_duplication = duplication_metrics["PERCENT_DUPLICATION"]
   }
 }
 

--- a/tasks/Qc.wdl
+++ b/tasks/Qc.wdl
@@ -567,7 +567,7 @@ task CheckContamination {
   output {
     File selfSM = "~{output_prefix}.selfSM"
     Float contamination = read_float(stdout())
-    Map[String, String] metrics = { "CONTAMINATION": read_string(stdout()) }
+    Map[String, String] metrics = { "FREEMIX": read_string(stdout()) }
   }
 }
 


### PR DESCRIPTION
Add outputs of parsed metrics and a step to evaluate them based on a thresholds file.  The thresholds is a three column TSV file with the name of the metric, the threshold value, and what operator to use (`=`, `<`, `>`, `<=`, or `>=`).  Note that the metric name should match the name of the metric as output by the tool that generated it.  While this is usually an intuitive name, occasionally it's more complicated.  Here's an example: 

Example:
```tsv
Q30_BASES	1000000000	>=
FREEMIX	0.01	<
PCT_CHIMERAS-PAIR	0.02	<=
```

Since the `PCT_CHIMERAS` metric is reported for `PAIR`, `FIRST_OF_PAIR`, and `SECOND_OF_PAIR`, we have to be clear which one we want.  The evaluator will output `n/a` if it doesn't find a matching metric (and, if it would otherwise `PASS`, it will instead yield `PASS*` for the `overall_evaluation` if any metrics were not found.)